### PR TITLE
Bug dont make unknown metadata ids fail - take 2

### DIFF
--- a/lib/rb/ext/struct_metadata.c
+++ b/lib/rb/ext/struct_metadata.c
@@ -33,15 +33,15 @@ static VALUE get_name_id(char* field_name) {
 // which deserializer doesn't know
 field_metadata* getFieldMetadataByID(struct_metadata* md, int id)
 {
+  field_metadata* fmd = NULL;
+
   DEBUG_FUNCTION_ENTRY();
-  if (md->maxid < id) {
-    DEBUG_FUNCTION_EXIT();
-    return NULL;
+  if (id <= md->maxid) {
+    fmd = md->index[id];
   }
-  if (md->index[id] == NULL) rb_raise(rb_eRuntimeError, "Entry %d for metadata object not present.", id);
 
   DEBUG_FUNCTION_EXIT();
-  return md->index[id];
+  return fmd;
 }
 
 // SLOOOOOOOW!!!

--- a/lib/rb/thrift.gemspec
+++ b/lib/rb/thrift.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = 'thrift'
-  s.version     = '0.9.0.7.wp'
+  s.version     = '0.9.0.8.wp'
   s.authors     = ['Thrift Developers','Ákos Vandra','Devin Ben-Hur']
   s.email       = ['dev@thrift.apache.org','avandra@whitepages.com','dbenhur@whitepages.com']
   s.homepage    = 'http://thrift.apache.org'


### PR DESCRIPTION
Following up on PR #9 --  when the field id is unknown (NULL in the metadata table) we should also just skip instead of raising.
